### PR TITLE
Support use of custom URL for visualizers

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,11 +13,12 @@ import (
 
 func main() {
 	target := flag.String("target", "depesz", "type of an explain visualizer to export")
+	url := flag.String("post_url", "", "Absolute URL to HTML <form> element's `action`")
 
 	flag.Parse()
 
 	ctx := context.Background()
-	planner, err := visualizer.New(*target)
+	planner, err := visualizer.New(*target, *url)
 
 	if err != nil {
 		log.Fatalf("failed to init a query plan exporter: %v", err)

--- a/visualizer/dalibo/dalibo.go
+++ b/visualizer/dalibo/dalibo.go
@@ -11,24 +11,29 @@ import (
 // visualizer constants
 const (
 	VisualizerType = "dalibo"
-	postURL        = "https://explain.dalibo.com/new"
+	defaultPostURL = "https://explain.dalibo.com/new"
 	planKey        = "plan"
 )
 
 // Dalibo defines a query plan exporter for the Dalibo visualizer.
 type Dalibo struct {
+	postURL string
 }
 
 // New creates a new Dalibo exporter.
-func New() *Dalibo {
-	return &Dalibo{}
+func New(url string) *Dalibo {
+	if url == "" {
+		url = defaultPostURL
+	}
+
+	return &Dalibo{postURL: url}
 }
 
 // Export posts plan to a visualizer and returns link to the visualization plan page.
 func (d *Dalibo) Export(plan string) (string, error) {
 	formVal := url.Values{planKey: []string{plan}}
 
-	explainURL, err := client.MakeRequest(postURL, formVal)
+	explainURL, err := client.MakeRequest(d.postURL, formVal)
 	if err != nil {
 		return "", fmt.Errorf("failed to make a request: %w", err)
 	}

--- a/visualizer/depesz/depesz.go
+++ b/visualizer/depesz/depesz.go
@@ -11,24 +11,29 @@ import (
 // visualizer constants
 const (
 	VisualizerType = "depesz"
-	visualizerURL  = "https://explain.depesz.com/"
+	defaultPostURL = "https://explain.depesz.com/"
 	planKey        = "plan"
 )
 
 // Depesz defines a query plan exporter for the Depesz visualizer.
 type Depesz struct {
+	postURL string
 }
 
 // New creates a new Depesz exporter.
-func New() *Depesz {
-	return &Depesz{}
+func New(url string) *Depesz {
+	if url == "" {
+		url = defaultPostURL
+	}
+
+	return &Depesz{postURL: url}
 }
 
 // Export posts plan to a visualizer and returns link to the visualization plan page.
 func (d *Depesz) Export(plan string) (string, error) {
 	formVal := url.Values{planKey: []string{plan}}
 
-	explainURL, err := client.MakeRequest(visualizerURL, formVal)
+	explainURL, err := client.MakeRequest(d.postURL, formVal)
 	if err != nil {
 		return "", fmt.Errorf("failed to make a request: %w", err)
 	}

--- a/visualizer/tensor/tensor.go
+++ b/visualizer/tensor/tensor.go
@@ -11,24 +11,29 @@ import (
 // visualizer constants
 const (
 	VisualizerType = "tensor"
-	visualizerURL  = "https://explain.tensor.ru/explain"
+	defaultPostURL = "https://explain.tensor.ru/explain"
 	planKey        = "explain"
 )
 
 // Tensor defines a query plan exporter for the Tensor visualizer.
 type Tensor struct {
+	postURL string
 }
 
 // New creates a new Tensor exporter.
-func New() *Tensor {
-	return &Tensor{}
+func New(url string) *Tensor {
+	if url == "" {
+		url = defaultPostURL
+	}
+
+	return &Tensor{postURL: url}
 }
 
 // Export posts plan to a visualizer and returns link to the visualization plan page.
 func (d *Tensor) Export(plan string) (string, error) {
 	formVal := url.Values{planKey: []string{plan}}
 
-	explainURL, err := client.MakeRequest(visualizerURL, formVal)
+	explainURL, err := client.MakeRequest(d.postURL, formVal)
 	if err != nil {
 		return "", fmt.Errorf("failed to make a request: %w", err)
 	}

--- a/visualizer/visualizer.go
+++ b/visualizer/visualizer.go
@@ -11,16 +11,16 @@ import (
 )
 
 // New creates a new query plan exporter by visualizer type.
-func New(visualizer string) (pgscanner.PlanExporter, error) {
+func New(visualizer string, url string) (pgscanner.PlanExporter, error) {
 	switch visualizer {
 	case dalibo.VisualizerType:
-		return dalibo.New(), nil
+		return dalibo.New(url), nil
 
 	case depesz.VisualizerType:
-		return depesz.New(), nil
+		return depesz.New(url), nil
 
 	case tensor.VisualizerType:
-		return tensor.New(), nil
+		return tensor.New(url), nil
 	}
 
 	return nil, fmt.Errorf("unknown visualizer given %q", visualizer)


### PR DESCRIPTION
If users wish to deploy their own local copy of the 3 popular visualizers,
they can provide a custom URL to keep their plans (and schema) private